### PR TITLE
Added the ability to call openai compatible api

### DIFF
--- a/llm/openai.go
+++ b/llm/openai.go
@@ -29,6 +29,20 @@ func NewOpenAI(apiKey, model string, params Parameters, logger *slog.Logger) Ope
 	}
 }
 
+// NewOpenAICompat creates a new OpenAI instance configured for OpenAI-compatible endpoints.
+// Supports custom API keys for different providers.
+func NewOpenAICompat(apiKey, baseURL, model string, params Parameters, logger *slog.Logger) OpenAI {
+	config := goopenai.DefaultConfig(apiKey)
+	config.BaseURL = baseURL
+
+	return OpenAI{
+		model:  model,
+		params: params,
+		client: goopenai.NewClientWithConfig(config),
+		logger: logger.With(slog.String("module", "openai-compat")),
+	}
+}
+
 // Chat sends a chat message to the OpenAI API.
 func (o OpenAI) Chat(messages []string) (string, error) {
 	msgs := make([]goopenai.ChatCompletionMessage, len(messages))

--- a/tests/rag_test.go
+++ b/tests/rag_test.go
@@ -564,6 +564,8 @@ func buildLLM(cfg llmConfig, logger *slog.Logger) (golightrag.LLM, error) {
 	switch strings.ToLower(cfg.Type) {
 	case "openai":
 		return llm.NewOpenAI(cfg.APIKey, cfg.Model, cfg.Parameters, logger), nil
+	case "openai-compat":
+		return llm.NewOpenAICompat(cfg.APIKey, cfg.Host, cfg.Model, cfg.Parameters, logger), nil
 	case "anthropic":
 		return llm.NewAnthropic(cfg.APIKey, cfg.Model, cfg.MaxTokens, cfg.Parameters), nil
 	case "ollama":


### PR DESCRIPTION
 go test -bench=. -timeout=0


```
time=2025-08-29T10:22:58.423-04:00 level=INFO msg="Inserting file" rag=light path=docs/christmascarol.txt 
time=2025-08-29T10:22:58.524-04:00 level=INFO msg="Upserting sources" rag=light package=golightrag function=Insert count=8 time=2025-08-29T10:22:58.533-04:00 level=INFO msg="Extracting entities" rag=light package=golightrag function=Insert count=8 time=2025-08-29T10:23:25.934-04:00 level=WARN msg="Retry parse result" rag=light package=golightrag function=Insert retry=1 error="failed to parse llm result: invalid character '<' looking for beginning of value" time=2025-08-29T10:23:52.162-04:00 level=WARN msg="Retry parse result" rag=light package=golightrag function=Insert retry=1 error="failed to parse llm result: invalid character '<' looking for beginning of value"
 time=2025-08-29T10:23:58.534-04:00 level=WARN msg="Retry extract" rag=light package=golightrag function=Insert retry=1 error="failed to call LLM: error sending request: Post \"http://localhost:1234/v1/chat/completions\": context deadline exceeded" time=2025-08-29T10:23:58.534-04:00 level=WARN msg="Retry extract" rag=light package=golightrag function=Insert retry=1 error="failed to call LLM: error sending request: Post \"http://localhost:1234/v1/chat/completions\": context deadline exceeded" time=2025-08-29T10:23:58.534-04:00 level=WARN msg="Retry extract" rag=light package=golightrag function=Insert retry=1 error="failed to call LLM: error sending request: Post \"http://localhost:1234/v1/chat/completions\": context deadline exceeded" 
time=2025-08-29T10:24:21.802-04:00 level=WARN msg="Retry parse result" rag=light package=golightrag function=Insert retry=2 error="failed to parse llm result: invalid character '<' looking for beginning of value" 
time=2025-08-29T10:24:34.413-04:00 level=WARN msg="Retry parse result" rag=light package=golightrag function=Insert retry=2 error="failed to parse llm result: invalid character '<' looking for beginning of value" 
time=2025-08-29T10:24:43.889-04:00 level=WARN msg="Retry parse result" rag=light package=golightrag function=Insert retry=2 error="failed to parse llm result: invalid character '<' looking for beginning of value" 
time=2025-08-29T10:24:55.717-04:00 level=WARN msg="Retry parse result" rag=light package=golightrag function=Insert retry=2 error="failed to parse llm result: invalid character '<' looking for beginning of value" 
time=2025-08-29T10:25:01.537-04:00 level=WARN msg="Retry extract" rag=light package=golightrag function=Insert retry=2 error="failed to call LLM: error sending request: Post \"http://localhost:1234/v1/chat/completions\": context deadline exceeded" time=2025-08-29T10:25:14.906-04:00 level=WARN msg="Retry parse result" rag=light package=golightrag function=Insert retry=3 error="failed to parse llm result: invalid character '<' looking for beginning of value"
```

Tested with this config on lm-studio

docker run -p 7687:7687 -p 7474:7474 -e NEO4J_AUTH=neo4j/password neo4j:latest
```
$cat config.yaml
neo4j_uri: "bolt://localhost:7687"
neo4j_user: "neo4j"
neo4j_password: "password"

rag_llm:
  type: "openai-compat"  # Options: openai, openai-compat, anthropic, ollama, openrouter
  api_key: "your-openai-api-key-here"
  host: "http://localhost:1234/v1/"
  model: "qwen3-0.6b-mlx"
  parameters:
    temperature: 0.7

eval_llm:
  type: "openai-compat"  # Options: openai, openai-compat, anthropic, ollama, openrouter
  api_key: "your-openai-api-key-here"
  host: "http://localhost:1234/v1/"
  model: "qwen3-0.6b-mlx"
  parameters:
    temperature: 0.7

embedding_api_key: "your-openai-api-key-here"

log_level: "info"  # Options: debug, info, warn, error
```
